### PR TITLE
fix dragged cards not moving

### DIFF
--- a/src/scripts/Solitaire.js
+++ b/src/scripts/Solitaire.js
@@ -430,9 +430,8 @@ Solitaire.handleTouchmove = function(e) {
 	if (objHovered(this.buttonsPos, relPos)) {
 		Layouter.handleMousemove.call(this.buttonsMenu, {pageX: pos.x, pageY: pos.y})
 	}
-	else {
-		this.handleMove(e, pos);
-	}
+
+	this.handleMove(e, pos);
 };
 
 /**
@@ -447,9 +446,8 @@ Solitaire.handleMousemove = function(e) {
 	if (objHovered(this.buttonsPos, relPos)) {
 		Layouter.handleMousemove.call(this.buttonsMenu, {pageX: pos.x, pageY: pos.y})
 	}
-	else {
-		this.handleMove(e, pos);
-	}
+
+	this.handleMove(e, pos);
 };
 
 Solitaire.prototype.handleMove = function(e, pos) {


### PR DESCRIPTION
Remove `else` from condition that checks if a button is hovered, so that
`handleMove` is always called.

Fixes #6